### PR TITLE
Fix missing include for std::runtime_error

### DIFF
--- a/src/exec.cpp
+++ b/src/exec.cpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <array>
+#include <stdexcept>
 
 std::string exec(const char* cmd) {
     std::array<char, 128> buffer;


### PR DESCRIPTION
Would fail to compile on Fedora 32