### PR TITLE
Fix integration test when using CMake Ninja generator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,14 @@ jobs:
         compiler:
           - { CC: "clang", CXX: "clang++" }
           - { CC: "gcc", CXX: "g++" }
+        build_generator:
+          - "Unix Makefiles"
+        include:
+          # Only want to test Ninja on one job
+          - distro: "ubuntu:latest"
+            compiler: { CC: "clang", CXX: "clang++" }
+            build_generator: "Ninja"
+
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}
     steps:
@@ -22,7 +30,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get update
-        apt-get install -y cmake clang gcc git build-essential
+        apt-get install -y cmake clang gcc git build-essential ninja-build
 
     - name: Install Fedora dependencies
       if: startsWith(matrix.distro, 'fedora')
@@ -39,7 +47,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTING=ON ..
+        cmake -G "${{ matrix.build_generator }}" -DCMAKE_VERBOSE_MAKEFILE=ON -DBUILD_TESTING=ON ..
         cmake --build . -j$(nproc)
 
     - name: Test

--- a/test/integration/src/CMakeLists.txt
+++ b/test/integration/src/CMakeLists.txt
@@ -7,4 +7,4 @@ add_subdirectory(a)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 target_link_libraries(main PRIVATE liba)
-set_target_properties(main PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,\\$ORIGIN/a,-rpath-link,a,-rpath-link,a/b,-rpath-link,a/b/c")
+set_target_properties(main PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,\\$ORIGIN/a")

--- a/test/integration/src/CMakeLists.txt
+++ b/test/integration/src/CMakeLists.txt
@@ -7,4 +7,4 @@ add_subdirectory(a)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 target_link_libraries(main PRIVATE liba)
-set_target_properties(main PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,$ORIGIN/a,-rpath-link,a,-rpath-link,a/b,-rpath-link,a/b/c")
+set_target_properties(main PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,\\$ORIGIN/a,-rpath-link,a,-rpath-link,a/b,-rpath-link,a/b/c")

--- a/test/integration/src/a/CMakeLists.txt
+++ b/test/integration/src/a/CMakeLists.txt
@@ -7,6 +7,6 @@ add_subdirectory(b)
 
 add_library(liba SHARED ${CMAKE_CURRENT_LIST_DIR}/liba.c)
 target_link_libraries(liba PRIVATE libb)
-set_target_properties(liba PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,$ORIGIN/b")
+set_target_properties(liba PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,\\$ORIGIN/b")
 
 add_library(libd SHARED ${CMAKE_CURRENT_LIST_DIR}/libd.c)

--- a/test/integration/src/a/b/CMakeLists.txt
+++ b/test/integration/src/a/b/CMakeLists.txt
@@ -7,4 +7,4 @@ add_subdirectory(c)
 
 add_library(libb SHARED ${CMAKE_CURRENT_LIST_DIR}/libb.c)
 target_link_libraries(libb PRIVATE libc)
-set_target_properties(libb PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags,-rpath,$ORIGIN/c")
+set_target_properties(libb PROPERTIES LINK_FLAGS "-Wl,--enable-new-dtags,-rpath,\\$ORIGIN/c")

--- a/test/integration/src/a/b/c/CMakeLists.txt
+++ b/test/integration/src/a/b/c/CMakeLists.txt
@@ -5,4 +5,4 @@ set(CMAKE_SKIP_BUILD_RPATH TRUE)
 
 add_library(libc SHARED ${CMAKE_CURRENT_LIST_DIR}/libc.c)
 target_link_libraries(libc PRIVATE libd)
-set_target_properties(libc PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,$ORIGIN/../..")
+set_target_properties(libc PROPERTIES LINK_FLAGS "-Wl,--disable-new-dtags,-rpath,\\$ORIGIN/../..")


### PR DESCRIPTION
`$` needs to be escaped for Ninja. These changes also work with default `Unix Makefile` generator.