### PR TITLE
add missing <sstream> include

### DIFF
--- a/src/deploy.cpp
+++ b/src/deploy.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include <libtree/deploy.hpp>
 #include <libtree/exec.hpp>
 


### PR DESCRIPTION
The file `deploy.cpp` uses `std::stringstream` but no `<sstream>` include is used.

This fixes the build with clang.