### PR TITLE
build: Support LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: libtree
 	$(CC) $(LIBTREE_CFLAGS) -c $?
 
 libtree: libtree.o
-	$(CC) $(LIBTREE_CFLAGS) -o $@ $?
+	$(CC) $(LDFLAGS) $^ -o $@
 
 check: libtree
 	for dir in $(sort $(wildcard tests/*)); do \


### PR DESCRIPTION
Allowing the user to set LDFLAGS is useful and lacking this ability even triggers some QA warnings on distros such as gentoo.

I also changed `$?` to `$^` which explicitly contains all of the prerequisites (Excluding duplicates) and is more standard. I then removed `$(LIBTREE_CFLAGS)` from the linker line where it is unneeded.