### PR TITLE
build: Add pedantic warning cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ include $(CURDIR)/Make.user
 endif
 
 CFLAGS ?= -O2
-LIBTREE_CFLAGS := $(CFLAGS) -Wall -std=c99 -D_FILE_OFFSET_BITS=64
+LIBTREE_CFLAGS := -std=c99 -Wall -Wextra -Wshadow -pedantic
+LIBTREE_DEFINES := -D_FILE_OFFSET_BITS=64
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
@@ -13,7 +14,7 @@ BINDIR ?= $(PREFIX)/bin
 all: libtree
 
 %.o: %.c
-	$(CC) $(LIBTREE_CFLAGS) -c $?
+	$(CC) $(CFLAGS) $(LIBTREE_CFLAGS) $(LIBTREE_DEFINES) -c $?
 
 libtree: libtree.o
 	$(CC) $(LDFLAGS) $^ -o $@


### PR DESCRIPTION
I am not sure if you are interested, but these are pedantic warnings cflags that I copied from another pedantic c99 project. I think they will help make the code more solid by exposing possible bugs.

I also added `LIBTREE_DEFINES` and set `$(CFLAGS)` directly in the recipe since that seems cleaner and more robust.

Additionally these expose new warnings in libtree for me.

__gcc-11.2.0__
```
$ make CC=gcc
gcc -O2 -std=c99 -Wall -Wextra -Wshadow -pedantic -D_FILE_OFFSET_BITS=64 -c libtree.c
libtree.c: In function ‘print_error’:
libtree.c:746:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  746 |     for (int i = 0; i < depth; ++i) {
      |                       ^
libtree.c: In function ‘parse_ld_library_path’:
libtree.c:1491:11: warning: declaration of ‘LD_LIBRARY_PATH’ shadows a global declaration [-Wshadow]
 1491 |     char *LD_LIBRARY_PATH = "LD_LIBRARY_PATH";
      |           ^~~~~~~~~~~~~~~
libtree.c:165:5: note: shadowed declaration is here
  165 |     LD_LIBRARY_PATH,
      |     ^~~~~~~~~~~~~~~
gcc  libtree.o -o libtree
```
__clang-12.0.0__
```
$ make CC=clang
clang -O2 -std=c99 -Wall -Wextra -Wshadow -pedantic -D_FILE_OFFSET_BITS=64 -c libtree.c
libtree.c:746:23: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    for (int i = 0; i < depth; ++i) {
                    ~ ^ ~~~~~
1 warning generated.
clang  libtree.o -o libtree
```