### PR TITLE
Preserve original timestamps when installing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ check:: libtree
 
 install: all
 	mkdir -p $(DESTDIR)$(BINDIR)
-	cp libtree $(DESTDIR)$(BINDIR)
+	cp -p libtree $(DESTDIR)$(BINDIR)
 	mkdir -p $(DESTDIR)$(SHAREDIR)/man/man1
-	cp doc/libtree.1 $(DESTDIR)$(SHAREDIR)/man/man1
+	cp -p doc/libtree.1 $(DESTDIR)$(SHAREDIR)/man/man1
 
 clean::
 	rm -f *.o libtree


### PR DESCRIPTION
Fedora suggests to preserve timestamps of the original installed files.