### PR TITLE
Add a --max-depth flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.1.0
+- Add a `--max-depth` flag to limit recursion depth. For example,
+  `libtree --max-depth 1 <file>` will show the resolved paths of direct dependencies
+  only.
+
 # v3.0.0
 - Rewritten in C99 with 0 external dependencies.
 - Significantly faster & smaller (~50KB statically compiled with musl libc, or

--- a/doc/libtree.1
+++ b/doc/libtree.1
@@ -34,6 +34,10 @@ Path to custom
 or
 .I ld-elf.so.conf
 file
+.IP "--max-depth n"
+Limit library traversal to a depth of at most
+.I n
+\[char46] The value cannot be larger than 32.
 .IP "--"
 All arguments after '--' are interpreted as paths, not flags.
 .SH ENVIRONMENT


### PR DESCRIPTION
Closes #70.

With `--max-depth 1` you get direct deps only, no need to do shell magic with `ldd | grep $(readelf -d <file> | grep NEEDED | ??)`:


```console
$ ./libtree --max-depth 1 /usr/bin/vim
/usr/bin/vim
├── libpthread.so.0 [ld.so.conf]
├── libpython3.8.so.1.0 [ld.so.conf]
├── libgpm.so.2 [ld.so.conf]
├── libacl.so.1 [ld.so.conf]
├── libcanberra.so.0 [ld.so.conf]
├── libselinux.so.1 [ld.so.conf]
└── libtinfo.so.6 [ld.so.conf]
```
