### PR TITLE
Make Makefile portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-ifeq (exists, $(shell [ -e $(CURDIR)/Make.user ] && echo exists ))
-include $(CURDIR)/Make.user
-endif
+-include Make.user
 
 CFLAGS ?= -O2
 LIBTREE_CFLAGS := -std=c99 -Wall -Wextra -Wshadow -pedantic
@@ -14,11 +12,12 @@ SHAREDIR ?= $(PREFIX)/share
 
 all: libtree
 
-%.o: %.c
-	$(CC) $(CFLAGS) $(LIBTREE_CFLAGS) $(LIBTREE_DEFINES) -c $?
+.c.o:
+	$(CC) $(CFLAGS) $(LIBTREE_CFLAGS) $(LIBTREE_DEFINES) -c $<
 
-libtree: libtree.o
-	$(CC) $(LDFLAGS) $^ -o $@
+libtree-objs = libtree.o
+libtree: $(libtree-objs)
+	$(CC) $(LDFLAGS) -o $@ $(libtree-objs)
 
 check:: libtree
 
@@ -32,6 +31,6 @@ clean::
 	rm -f *.o libtree
 
 clean check::
-	for dir in $(sort $(wildcard tests/*)); do \
-		$(MAKE) -C $$dir $@ || break ;\
+	ls -1 -d tests/* | while read dir; do \
+		$(MAKE) -C "$$dir" $@ || break ;\
 	done

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,6 @@ clean::
 	rm -f *.o libtree
 
 clean check::
-	ls -1 -d tests/* | while read dir; do \
+	find tests -type d -mindepth 1 -maxdepth 1 | while read -r dir; do \
 		$(MAKE) -C "$$dir" $@ || break ;\
 	done


### PR DESCRIPTION
- Just include Make.user directly
- Replace SunPro-style pattern rule by suffix rule; neither can merge
  targets into a single call, so no point in using $?
- Replace unportable $^ with a variable.
- Replace wildcard+sort with a call to ls, also for portability.