### PR TITLE
Match automake variable names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
--include Make.user
-
 CFLAGS ?= -O2
 LIBTREE_CFLAGS = -std=c99 -Wall -Wextra -Wshadow -pedantic
 LIBTREE_DEFINES = -D_FILE_OFFSET_BITS=64
@@ -39,3 +37,5 @@ clean check::
 	find tests -mindepth 1 -maxdepth 1 -type d | while read -r dir; do \
 		$(MAKE) -C "$$dir" $@ || exit 1 ;\
 	done
+
+-include Make.user

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ CFLAGS ?= -O2
 LIBTREE_CFLAGS = -std=c99 -Wall -Wextra -Wshadow -pedantic
 LIBTREE_DEFINES = -D_FILE_OFFSET_BITS=64
 
-prefix = /usr/local
+# uppercase variables for backwards compatibility only:
+PREFIX = /usr/local
+
+prefix = $(PREFIX)
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 datarootdir = $(prefix)/share

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ CFLAGS ?= -O2
 LIBTREE_CFLAGS = -std=c99 -Wall -Wextra -Wshadow -pedantic
 LIBTREE_DEFINES = -D_FILE_OFFSET_BITS=64
 
-PREFIX ?= /usr/local
-BINDIR ?= $(PREFIX)/bin
-SHAREDIR ?= $(PREFIX)/share
+prefix = /usr/local
+exec_prefix = $(prefix)
+bindir = $(exec_prefix)/bin
+datarootdir = $(prefix)/share
+mandir = $(datarootdir)/man
 
 .PHONY: all check install clean
 
@@ -20,10 +22,10 @@ libtree: $(libtree-objs)
 	$(CC) $(LDFLAGS) -o $@ $(libtree-objs)
 
 install: all
-	mkdir -p $(DESTDIR)$(BINDIR)
-	cp -p libtree $(DESTDIR)$(BINDIR)
-	mkdir -p $(DESTDIR)$(SHAREDIR)/man/man1
-	cp -p doc/libtree.1 $(DESTDIR)$(SHAREDIR)/man/man1
+	mkdir -p $(DESTDIR)$(bindir)
+	cp -p libtree $(DESTDIR)$(bindir)
+	mkdir -p $(DESTDIR)$(mandir)/man1
+	cp -p doc/libtree.1 $(DESTDIR)$(mandir)/man1
 
 check:: libtree
 


### PR DESCRIPTION
Also, allow overriding the manual pages directory.